### PR TITLE
Application should expose metrics using default POD convention

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 management.endpoints.web.exposure.include=prometheus
+management.endpoints.web.base-path=/
+management.endpoints.web.path-mapping.prometheus=metrics


### PR DESCRIPTION
Application should expose metrics using default POD convention [1] used by Prometheus Kubernetes service discovery. That would save user extra configuration via k8s annotations.

[1] https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config